### PR TITLE
Feat/oauth signup db #4

### DIFF
--- a/src/main/java/Integration/integration/dto/OAuthUserInfo.java
+++ b/src/main/java/Integration/integration/dto/OAuthUserInfo.java
@@ -1,0 +1,17 @@
+package Integration.integration.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import Integration.integration.entity.Provider;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OAuthUserInfo {
+    private Provider provider;
+    private String providerId;
+    private String email;
+    private String name;
+    private String picture;
+}

--- a/src/main/java/Integration/integration/entity/Provider.java
+++ b/src/main/java/Integration/integration/entity/Provider.java
@@ -1,0 +1,6 @@
+package Integration.integration.entity;
+
+public enum Provider {
+    GOOGLE,
+    KAKAO
+}

--- a/src/main/java/Integration/integration/entity/UserOauths.java
+++ b/src/main/java/Integration/integration/entity/UserOauths.java
@@ -1,0 +1,34 @@
+package Integration.integration.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "user_oauths")
+public class UserOauths {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", unique = true, nullable = false)
+    private Users user;
+
+    @Enumerated(EnumType.STRING)
+    private Provider provider;  // google, kakao
+
+    @Column(name = "provider_id", nullable = false)
+    private String providerId;
+
+    private String email;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt = LocalDateTime.now();
+}
+

--- a/src/main/java/Integration/integration/entity/Users.java
+++ b/src/main/java/Integration/integration/entity/Users.java
@@ -1,25 +1,52 @@
 package Integration.integration.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import lombok.Getter;
-import lombok.Setter;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "users")
 public class Users {
+
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, nullable = false)
+    @Column(nullable = false, unique = true, length = 255)
     private String email;
 
-    private String password;
+    @Column(length = 255)
+    private String password; // 소셜 로그인 시 null 가능
 
-    @Column(unique = true, nullable = false)
+    @Column(nullable = false, length = 50)
     private String nickname;
+
+    @Column(name = "profile_image", length = 255)
+    private String profileImage;
+
+    @Column(length = 20)
+    private String phone;
+
+    @Column(name = "email_verified")
+    private Boolean emailVerified = false;
+
+    @Column(length = 20)
+    private String role = "USER";
+
+    @Column(name = "is_active")
+    private Boolean isActive = true;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    // === 연관관계 ===
+
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private UserOauths userOauths;
 }

--- a/src/main/java/Integration/integration/repository/UserOauthRepository.java
+++ b/src/main/java/Integration/integration/repository/UserOauthRepository.java
@@ -1,0 +1,11 @@
+package Integration.integration.repository;
+
+import Integration.integration.entity.UserOauths;
+import Integration.integration.entity.Provider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserOauthRepository extends JpaRepository<UserOauths, Long> {
+    Optional<UserOauths> findByProviderAndProviderId(Provider provider, String providerId);
+}

--- a/src/main/java/Integration/integration/service/CustomOAuth2UserService.java
+++ b/src/main/java/Integration/integration/service/CustomOAuth2UserService.java
@@ -1,0 +1,16 @@
+package Integration.integration.service;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest)
+            throws OAuth2AuthenticationException {
+        return super.loadUser(userRequest); // 여기선 단순 정보만 받아옴
+    }
+}

--- a/src/main/java/Integration/integration/service/OAuthService.java
+++ b/src/main/java/Integration/integration/service/OAuthService.java
@@ -1,0 +1,54 @@
+package Integration.integration.service;
+
+import Integration.integration.dto.OAuthUserInfo;
+import Integration.integration.entity.UserOauths;
+import Integration.integration.entity.Users;
+import Integration.integration.repository.UserOauthRepository;
+import Integration.integration.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthService {
+
+    private final UsersRepository usersRepository;
+    private final UserOauthRepository userOauthRepository;
+
+    public Users handleOAuthLogin(OAuthUserInfo oAuthInfo) {
+        // 1. 기존 user_oauths 확인
+        Optional<UserOauths> existing = userOauthRepository.findByProviderAndProviderId(
+                oAuthInfo.getProvider(), oAuthInfo.getProviderId());
+
+        if (existing.isPresent()) {
+            return existing.get().getUser(); // 기존 회원 로그인 처리
+        }
+
+        // 2. users 테이블에 새 유저 생성
+        Users user = Users.builder()
+                .email(oAuthInfo.getEmail())
+                .nickname(oAuthInfo.getName())
+                .profileImage(oAuthInfo.getPicture())
+                .emailVerified(true)
+                .role("USER")
+                .isActive(true)
+                .build();
+
+        usersRepository.save(user);
+
+        // 3. user_oauths 테이블에 연동 정보 저장
+        UserOauths oauth = new UserOauths();
+        oauth.setUser(user);
+        oauth.setProvider(oAuthInfo.getProvider());
+        oauth.setProviderId(oAuthInfo.getProviderId());
+        oauth.setEmail(oAuthInfo.getEmail());
+
+        userOauthRepository.save(oauth);
+
+        return user;
+    }
+
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,6 +36,8 @@ spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/o
 spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
 spring.security.oauth2.client.provider.kakao.user-name-attribute=id
 
+spring.security.oauth2.client.registration.google.client-authentication-method=client_secret_post
+
 # jwt
 jwt.secret=${JWT_SECRET}
 


### PR DESCRIPTION
## ✅ PR 종류

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

---

## 📌 변경 사항 요약

카카오, 구글 OAuth로그인 시 프론트에 JSON으로 정보 간략히 띄우고, DB에 유저 정보 저장되도록 함

---

## 📝 상세 설명

## 주요 변경 사항
- `OAuthService` 생성: 소셜 로그인 시 기존/신규 사용자 처리 로직 구현
- `UserOauths`, `Users` 엔티티 및 레포지토리 구성
- `CustomOAuth2UserService` 구현: OAuth 사용자 정보 조회
- `OAuth2SuccessHandler` 구현: 로그인 성공 후 JWT 발급 및 리디렉션
- `application.properties`: Google OAuth 인증 방식 설정 (`client-authentication-method=client_secret_post`)

---

## 코드 설명 및 고려 사항

- `OAuthService` : 소셜 로그인 사용자 등록과 기존 사용자 조회
  - 기존 계정이 없을 경우 `Users`, `UserOauths` 테이블 함께 저장해서 내부 계정과 소셜 계정 연동하도록 처리

- `OAuth2SuccessHandler` : 로그인 성공 직후 JWT 발급하고 클라이언트에 토큰 전달
  - 클라이언트는 토큰 기반으로 인증을 유지

- `CustomOAuth2UserService` : 구글, 카카오로부터 사용자 정보를 받아오는 역할만 수행
  - 사용자 저장 등 비즈니스 로직은 `OAuthService`가 처리 -> 기능 분리해서 차후 유지보수 용이하도록 함

---

## 🔍 관련 이슈

- resolved: #4 

---

## ✅ 테스트 결과

- [x] 정상 동작 확인함
- [x] 버그 없음 확인함
- [ ] UI 변화 있음 (스크린샷 첨부 필요)

스크린샷 :
- 구글 회원가입/로그인 성공 시 
<img width="956" height="134" alt="image" src="https://github.com/user-attachments/assets/ada09a75-ed78-4a5e-bf62-e5f046e93923" />
- 카카오 회원가입/로그인 성공 시
<img width="956" height="137" alt="image" src="https://github.com/user-attachments/assets/36c7803c-010d-4e4a-9095-ab846d37dca4" />
- DB에 잘 들어온 모습
1. users 테이블
<img width="974" height="84" alt="image" src="https://github.com/user-attachments/assets/5cebcab3-c63b-49b3-9a14-10af2efbd5dc" />

2. user_oauths 테이블
<img width="1540" height="108" alt="image" src="https://github.com/user-attachments/assets/1ab84a36-c659-4ec9-9b07-8ff90c702175" />

---

## 🧩 기타 참고 사항

> 코드리뷰 시 알아두면 좋을 내용이 있다면 작성해주세요.

---

